### PR TITLE
chore: rename devops-ci to platform-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,31 +11,31 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                               @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
+/.github/                                               @hashgraph/platform-ci @hashgraph/release-engineering-managers
+/.github/workflows/                                     @hashgraph/platform-ci @hashgraph/platform-ci-committers
 
 # Cmake project files and inline plugins
-**/.clang*                                              @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/.clang-format                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/.clang-tidy                                          @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/CMakeLists.txt                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/CMakePresets.json                                    @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/Makefile                                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/.clang*                                              @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/.clang-format                                        @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/.clang-tidy                                          @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/CMakeLists.txt                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/CMakePresets.json                                    @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/Makefile                                             @hashgraph/platform-ci @hashgraph/platform-ci-committers
 
 # Codacy Tool Configurations
-/config/                                                @hashgraph/devops-ci @hashgraph/release-engineering-managers
-.remarkrc                                               @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/config/                                                @hashgraph/platform-ci @hashgraph/release-engineering-managers
+.remarkrc                                               @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                             @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                              @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/README.md                                              @hashgraph/platform-ci @hashgraph/release-engineering-managers
 **/LICENSE                                              @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                          @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/codecov.yml                                          @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                           @hashgraph/devops-ci @hashgraph/release-engineering-managers
-**/.gitignore.*                                         @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/.gitignore                                           @hashgraph/platform-ci @hashgraph/release-engineering-managers
+**/.gitignore.*                                         @hashgraph/platform-ci @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:

Rename `devops-ci` to `platform-ci` and `devops-ci-committers` to `platform-ci-committers`

**Related Issue(s)**:

Fixes #48
